### PR TITLE
On startup, process sub directories of the main videos directory

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -1,7 +1,5 @@
 # Video Server
 
-Node.js server written in typescript, that provides a web GUI to navigate the `/data` directory, and stream any `.mp4` video files found.
-
-Place your videos inside of directories. Place those directories inside of `/data` folder.
+Node.js server written in typescript, that provides a web GUI to navigate the `/video` directory, and stream any `.mp4` video files found.
 
 To start the server: `npm run dev`

--- a/server/src/handlers/tags/tag_videos.ts
+++ b/server/src/handlers/tags/tag_videos.ts
@@ -41,12 +41,7 @@ const build_tags_to_add = async (tag_set: Set<string>): Promise<Tag[]> => {
   return tags;
 };
 
-const TagVideos = async (req: Request, res: Response): Promise<void> => {
-  console.log("entered tag vides");
-  const videos: VideoMeta[] = req.body.videos;
-  console.log("videos:", videos.length);
-  const tags: Tag[] = req.body.tags;
-  console.log("tags:", tags.length);
+export const apply_tags_to_videos = async (videos: VideoMeta[], tags: Tag[]): Promise<void> => {
   videos.forEach(async (v) => {
     const tags_set = build_tag_set(tags);
     console.log("tags_set is", tags_set.size);
@@ -66,6 +61,15 @@ const TagVideos = async (req: Request, res: Response): Promise<void> => {
     video_to_tag.tags = new_tags;
     await getRepository(VideoMeta).save(video_to_tag);
   });
+};
+
+const TagVideos = async (req: Request, res: Response): Promise<void> => {
+  console.log("entered tag vides");
+  const videos: VideoMeta[] = req.body.videos;
+  console.log("videos:", videos.length);
+  const tags: Tag[] = req.body.tags;
+  console.log("tags:", tags.length);
+  await apply_tags_to_videos(videos, tags);
   res.status(200).json({ message: "done" });
 };
 

--- a/server/src/models/video_meta.ts
+++ b/server/src/models/video_meta.ts
@@ -1,6 +1,7 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToMany, Index } from "typeorm";
+import { Entity, PrimaryGeneratedColumn, Column, ManyToMany, Index, getRepository } from "typeorm";
 import path from "path";
 import { Tag } from "./tag";
+import { apply_tags_to_videos } from "../handlers/tags/tag_videos";
 
 @Entity()
 export class VideoMeta {
@@ -31,5 +32,9 @@ export class VideoMeta {
     this.name = path.basename(path_);
     this.path = path.join(path_);
     this.parent_path = path.dirname(path_);
+  }
+
+  static async apply_tag(video: VideoMeta, tag: Tag): Promise<void> {
+    await apply_tags_to_videos([video], [tag]);
   }
 }

--- a/server/src/start.ts
+++ b/server/src/start.ts
@@ -1,8 +1,12 @@
 import app from "./app";
+import { Directory } from "./models/directory";
 
 const port = process.env.PORT || 5000;
 
-app.listen(port, () => {
+app.listen(port, async () => {
   console.log(process.argv);
   console.log(`listening on: http://localhost:${port}/"`);
+  const main_dir = new Directory("videos");
+  await main_dir.read_contents();
+  await main_dir.process_sub_dirs(main_dir.directory_paths);
 });


### PR DESCRIPTION
On startup, process sub directories of the main videos directory. For every subdirectory: create an associated tag if one doesn't exist. Apply that tag to all videos in that subdirectory.